### PR TITLE
add resolvers options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,28 @@ const environment = new Environment({network, store});
 // use environment in <QueryRenderer>
 
 ```
+
+### Mocking custom scalar types
+If your schema has custom scalar types you'll need to use the `resolvers` option to ensure those types get mocked correctly. Pass this option a resolve function for each custom scalar.
+
+```js
+...
+import getNetworkLayer from 'relay-mock-network-layer';
+import {GraphQLScalarType} from 'graphql';
+
+...
+
+getNetworkLayer({
+    schema,
+    mocks: {...},
+    resolvers: {
+        CustomScalar: new GraphQLScalarType({
+            name: 'CustomScalar',
+            parseLiteral: () => {},
+            parseValue: () => {},
+            serialize: () => {}
+        }),
+        CustomScalar2: ...
+    }
+});
+```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const environment = new Environment({network, store});
 ```
 
 ### Mocking custom scalar types
-If your schema has custom scalar types you'll need to use the `resolvers` option to ensure those types get mocked correctly. Pass this option a resolve function for each custom scalar.
+If your schema has custom scalar types you'll need to use the `resolvers` option to ensure those types get mocked correctly. Pass this option an object containing a resolve function for each custom scalar.
 
 ```js
 ...

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const { makeExecutableSchema, addMockFunctionsToSchema } = require('graphql-tools');
 const { graphql, printSchema, buildClientSchema } = require('graphql');
 
-module.exports = function getNetworkLayer({schema, mocks}) {
+module.exports = function getNetworkLayer({schema, mocks, resolvers}) {
     return function fetchQuery(
         operation,
         variableValues
@@ -12,7 +12,7 @@ module.exports = function getNetworkLayer({schema, mocks}) {
             schema = printSchema(buildClientSchema(schema.data));
         }
 
-        const executableSchema = makeExecutableSchema({typeDefs: schema});
+        const executableSchema = makeExecutableSchema({typeDefs: schema, resolvers});
 
         // Add mocks, modifies schema in place
         addMockFunctionsToSchema({ schema: executableSchema, mocks });


### PR DESCRIPTION
from http://dev.apollodata.com/tools/graphql-tools/mocking.html#Customizing-mocks
```
Note: If your schema has custom scalar types, you still need to define 
the __serialize, __parseValue, and __parseLiteral functions, and pass
them inside the second argument to makeExecutableSchema.
```