### PR TITLE
Reject with a single error to follow Relay’s API.

### DIFF
--- a/RelayMockNetworkLayerError.js
+++ b/RelayMockNetworkLayerError.js
@@ -1,0 +1,31 @@
+function RelayMockNetworkLayerError(errors) {
+  const distinctMessages = errors
+    .map(e => e.message)
+    .filter((value, index, messages) => messages.indexOf(value) === index);
+  const instance = new Error(
+    'RelayMockNetworkLayerError: ' + distinctMessages.join(' - ')
+  );
+  instance.originalErrors = errors;
+  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(instance, RelayMockNetworkLayerError);
+  }
+  return instance;
+}
+
+RelayMockNetworkLayerError.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: Error,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  },
+});
+
+if (Object.setPrototypeOf) {
+  Object.setPrototypeOf(RelayMockNetworkLayerError, Error);
+} else {
+  RelayMockNetworkLayerError.__proto__ = Error;
+}
+
+module.exports = RelayMockNetworkLayerError;

--- a/RelayMockNetworkLayerError.js
+++ b/RelayMockNetworkLayerError.js
@@ -1,31 +1,14 @@
-function RelayMockNetworkLayerError(errors) {
-  const distinctMessages = errors
-    .map(e => e.message)
-    .filter((value, index, messages) => messages.indexOf(value) === index);
-  const instance = new Error(
-    'RelayMockNetworkLayerError: ' + distinctMessages.join(' - ')
-  );
-  instance.originalErrors = errors;
-  Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
-  if (Error.captureStackTrace) {
-    Error.captureStackTrace(instance, RelayMockNetworkLayerError);
-  }
-  return instance;
-}
-
-RelayMockNetworkLayerError.prototype = Object.create(Error.prototype, {
-  constructor: {
-    value: Error,
-    enumerable: false,
-    writable: true,
-    configurable: true,
-  },
-});
-
-if (Object.setPrototypeOf) {
-  Object.setPrototypeOf(RelayMockNetworkLayerError, Error);
-} else {
-  RelayMockNetworkLayerError.__proto__ = Error;
+class RelayMockNetworkLayerError extends Error {
+    constructor(errors) {
+        const distinctMessages = errors
+            .map(e => e.message)
+            .filter((value, index, messages) => messages.indexOf(value) === index);
+        super("RelayMockNetworkLayerError: " + distinctMessages.join(" - "));
+        this.originalErrors = errors;
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+    }
 }
 
 module.exports = RelayMockNetworkLayerError;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const { makeExecutableSchema, addMockFunctionsToSchema } = require('graphql-tools');
 const { graphql, printSchema, buildClientSchema } = require('graphql');
+const RelayMockNetworkLayerError = require("./RelayMockNetworkLayerError");
 
 module.exports = function getNetworkLayer({schema, mocks, resolvers}) {
     return function fetchQuery(
@@ -19,16 +20,16 @@ module.exports = function getNetworkLayer({schema, mocks, resolvers}) {
 
         return graphql(executableSchema, operation.text, null, null, variableValues).then(
             // Trigger Relay error in case of GraphQL errors (or errors in mutation response)
-            // NOTICE that data might contain values even when errors are present
             // See https://github.com/facebook/relay/issues/1816
-            
+
             result => {
                 if (result.errors && result.errors.length > 0) {
-                    return Promise.reject(result);
+                    return Promise.reject(new RelayMockNetworkLayerError(result.errors));
                 }
                 return Promise.resolve(result);
             }
         );
     }
 };
+
 


### PR DESCRIPTION
The `error` param of the `QueryRenderer` render prop is expected to be a single error object.