### PR TITLE
Update graphql-tools@4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ const network = Network.create(getNetworkLayer({
             state: 'NY',
             zipCode: '10012',
         })
-    }
+    },
+
+    // See https://www.apollographql.com/docs/graphql-tools/mocking.html#Mocking-interfaces
+    preserveResolvers: false,
+
+    // Forward along other options to `makeExecutableSchema`.
+    ...schemaDefinitionOptions
 }));
 
 // Create an environment using this network:

--- a/index.js
+++ b/index.js
@@ -4,23 +4,54 @@ const { makeExecutableSchema, addMockFunctionsToSchema } = require('graphql-tool
 const { graphql, printSchema, buildClientSchema } = require('graphql');
 const RelayMockNetworkLayerError = require('./RelayMockNetworkLayerError');
 
+const defaultSchemaDefinitionOptions = {
+    resolverValidationOptions: {
+        // Silence error regarding missing Relay `Node` type
+        // https://github.com/este/este/issues/1513#issuecomment-385752066
+        requireResolversForResolveType: false,
+    },
+};
+
 /**
  * @param {Object} networkConfig - The configuration for the mock network layer.
  * @param {(string|Object)} networkConfig.schema - If string, the graphql schema SDL. If object, the JSON introspection query.
  * @param {Object} networkConfig.mocks - Mock primative resolvers, passed directly to addMockFunctionsToSchema.
  * @param {Object} networkConfig.resolvers - Default resolvers for a schema.
- * @param {Object} [networkConfig.resolveQueryFromOperation] - If relay operation query text does not exist, used to resolve the query from the operation. Useful for persisted query support.
+ * @param {Function} [networkConfig.resolveQueryFromOperation] - If relay operation query text does not exist, used to resolve the query from the operation. Useful for persisted query support.
  */
-function getNetworkLayer({ schema, mocks, resolvers, resolveQueryFromOperation }) {
+module.exports = function getNetworkLayer({
+    schema,
+    mocks,
+    resolvers,
+    resolveQueryFromOperation,
+
+    /** https://www.apollographql.com/docs/graphql-tools/mocking.html#Mocking-interfaces */
+    preserveResolvers = false,
+
+    /**
+     * https://github.com/apollographql/graphql-tools/blob/master/src/Interfaces.ts#L125
+     * @type IExecutableSchemaDefinition
+     */
+    ...schemaDefinitionOptions
+}) {
+    schemaDefinitionOptions = {
+        ...defaultSchemaDefinitionOptions,
+        ...schemaDefinitionOptions,
+    };
+
     return function fetchQuery(operation, variableValues) {
         if (typeof schema === 'object' && schema.data) {
             schema = printSchema(buildClientSchema(schema.data));
         }
 
-        const executableSchema = makeExecutableSchema({ typeDefs: schema, resolvers });
+        const executableSchema = makeExecutableSchema({
+            typeDefs: schema,
+            resolvers,
+            ...schemaDefinitionOptions,
+        });
 
         // Add mocks, modifies schema in place
-        addMockFunctionsToSchema({ schema: executableSchema, mocks });
+        addMockFunctionsToSchema({ schema: executableSchema, mocks, preserveResolvers });
 
         const query =
             (resolveQueryFromOperation && resolveQueryFromOperation(operation)) || operation.text;
@@ -44,5 +75,3 @@ function getNetworkLayer({ schema, mocks, resolvers, resolveQueryFromOperation }
         );
     };
 }
-
-module.exports = getNetworkLayer;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Rob Richard <rob@1stdibs.com>",
   "license": "MIT",
   "dependencies": {
-    "graphql-tools": "^1.2.1"
+    "graphql-tools": "^4.0.2"
   },
   "peerDependencies": {
     "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,27 +2,65 @@
 # yarn lockfile v1
 
 
-"@types/graphql@^0.9.0":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"
+apollo-link@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.3.tgz#9bd8d5fe1d88d31dc91dae9ecc22474d451fb70d"
+  integrity sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==
+  dependencies:
+    apollo-utilities "^1.0.0"
+    zen-observable-ts "^0.8.10"
+
+apollo-utilities@^1.0.0, apollo-utilities@^1.0.1:
+  version "1.0.24"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.24.tgz#77d2d3008bb9ee52aa76b799ce7a8d6cb6cf8a1c"
+  integrity sha512-cOXtrkio3wKfggp/zKCzQYxSZZRND/njNVmUksM1cckoJF3g/2o3bhh6z0HPhNhee8qzJzVXtl+3vmwXYGh0Gg==
+  dependencies:
+    fast-json-stable-stringify "^2.0.0"
 
 deprecated-decorator@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz#00966317b7a12fe92f3cc831f7583af329b86c37"
+  integrity sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=
 
-graphql-tools@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-1.2.3.tgz#079bf4d157e46c0a0bae9fec117e0eea6e03ba2c"
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
+
+graphql-tools@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-4.0.2.tgz#9da22974cc6bf6524ed4f4af35556fd15aa6516d"
+  integrity sha512-GijRFaHmSbyVphtTb23wd6wxXNkct9usiXHl2v4cOFNdUWe3Qz7VqoNyOwINlff2nf01xO+lCkhVlay0svJqfQ==
   dependencies:
+    apollo-link "^1.2.3"
+    apollo-utilities "^1.0.1"
     deprecated-decorator "^0.1.6"
-    uuid "^3.0.1"
-  optionalDependencies:
-    "@types/graphql" "^0.9.0"
+    iterall "^1.1.3"
+    uuid "^3.1.0"
+
+iterall@^1.1.3:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 prettier@1.14.3:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
+  integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
 
-uuid@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+uuid@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+zen-observable-ts@^0.8.10:
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz#18e2ce1c89fe026e9621fd83cc05168228fce829"
+  integrity sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==
+  dependencies:
+    zen-observable "^0.8.0"
+
+zen-observable@^0.8.0:
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.10.tgz#85ad75d41fed82e5b4651bd64ca117b2af960182"
+  integrity sha512-UXEh0ekA/QWYI2NkLHc5IH0V1FstIN4qGVlVvq0DQAS3oR72mofYHkjJ2f4ysMKRAziwnACzg3c0ZuG+SMDu8w==


### PR DESCRIPTION
While working on improving the DX error output in our tests noticed that `graphql-tools` is a few major versions behind (`1.2.1` -> `4.0.2`). This updates it to latest as well as allows users to pass the full option set along to [`makeExectuableSchema`](https://github.com/apollographql/graphql-tools/blob/master/src/Interfaces.ts#L125). 

Example: 

```js
getNetworkLayer({
  schema,
  mocks: {
    FormattedNumber: () => FormattedNumber,
    ...mockResolvers,
  },
  resolverValidationOptions: {
    requireResolversForResolveType: true,
  },
  ...otherOptionsToPass
})

```

Testing it on our codebase required us to set `requireResolversForResolveType: false` in order for old behavior to be preserved as the default in `graphql-tools` is `true`, which is where we would like to get to. (See [here](https://github.com/este/este/issues/1513#issuecomment-385752066) for an explanation of the error we were receiving.) Not sure what the implications are for this far of a jump but here are some links to their release pages: 

- https://github.com/apollographql/graphql-tools/releases/tag/4.0.0
- https://github.com/apollographql/graphql-tools/releases/tag/v3.0.0
- https://github.com/apollographql/graphql-tools/releases/tag/v2.0.0

See https://github.com/artsy/reaction/pull/1465 for an example of what we're working towards surfacing. 